### PR TITLE
go1.5 vendor experiment (https://golang.org/s/go15vendor)

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -7,3 +7,4 @@ RUN apk add go git bzr
 RUN rm -rf /var/cache/apk/*
 
 ENV GOPATH /go
+ENV GO15VENDOREXPERIMENT 1


### PR DESCRIPTION
Can't build however
```sh
romand@romand ~/iron/dockers/go go1.5vendorexperiment±
% docker build -t romand/go:latest .
…
Step 0 : FROM iron/base
 ---> b77c28b9b145
Step 1 : RUN apk update && apk upgrade
 ---> Running in baf4bbe95c4d
/bin/sh: apk: not found
INFO[0000] The command [/bin/sh -c apk update && apk upgrade] returned a non-zero code: 127 
```
@treeder do I miss smth?