### PR TITLE
Creating separate Dockerfiles for the JRE and JDK

### DIFF
--- a/java/java-1.7/README.md
+++ b/java/java-1.7/README.md
@@ -1,28 +1,23 @@
+# Java 1.7 JRE Image
+
+This is a small, [Alpine Linux](http://www.alpinelinux.org/) based Docker image
+that contains the Java 1.7 JVM. It's useful for executing Java bytecode, but note
+that it doesn't contain the JDK, so you can't use it to compile Java code.
 
 ## Using
 
 ```sh
-docker run -it --rm iron/java java -version
+docker run -it --rm iron/java:1.7 java -version
 ```
 
 ## Building this image
 
 ```sh
-docker build -t iron/java:latest .
-```
-
-Tag the version, check it with `docker run --rm iron/java java -version`:
-
-```sh
-docker tag iron/java:latest iron/java:X.Y.Z
+docker build -t iron/java:1.7 .
 ```
 
 Push:
 
 ```sh
-docker push iron/java
+docker push iron/java:1.7
 ```
-
-## TODO
-
-* [ ] we could maybe make a few different versions of this, one for building and a smaller one for running (openjdk7-jre).

--- a/java/java-1.8/Dockerfile
+++ b/java/java-1.8/Dockerfile
@@ -3,7 +3,8 @@ FROM iron/base
 RUN echo 'http://nl.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
 RUN apk update && apk upgrade
 
-RUN apk add openjdk8
+# openjdk-8-base contains no GUI support. see https://pkgs.alpinelinux.org/package/testing/x86_64/openjdk8-jre-base
+RUN apk add openjdk8-jre-base
 
 # Clean APK cache
 RUN rm -rf /var/cache/apk/*

--- a/java/java-1.8/README.md
+++ b/java/java-1.8/README.md
@@ -1,3 +1,8 @@
+# Java 1.8 JRE Image
+
+This is a small, [Alpine Linux](http://www.alpinelinux.org/) based Docker image
+that contains the Java 1.8 JVM. It's useful for executing Java bytecode, but note
+that it doesn't contain the JDK, so you can't use it to compile Java code.
 
 ## Using
 

--- a/java/java-dev-1.7/Dockerfile
+++ b/java/java-dev-1.7/Dockerfile
@@ -3,8 +3,9 @@ FROM iron/base
 RUN echo 'http://nl.alpinelinux.org/alpine/v2.6/main' >> /etc/apk/repositories && echo 'http://nl.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
 RUN apk update && apk upgrade
 
-# openjdk7-jre-base contains no GUI support. see https://pkgs.alpinelinux.org/package/main/x86_64/openjdk7-jre-base
-RUN apk add openjdk7-jre-base
+RUN apk add openjdk7
+# puts javac in the PATH
+ENV PATH=/usr/lib/jvm/java-1.7-openjdk/bin:$PATH
 
 # Clean APK cache
 RUN rm -rf /var/cache/apk/*

--- a/java/java-dev-1.7/README.md
+++ b/java/java-dev-1.7/README.md
@@ -1,0 +1,24 @@
+# Java 1.7 JDK Image
+
+This is a small, [Alpine Linux](http://www.alpinelinux.org/) based Docker image
+that contains the Java 1.7 JDK. You can use it to compile and execute your Java code.
+
+If you're executing Java code in production, however, we recommend you use iron/java:1.7.
+
+## Using
+
+```sh
+docker run -it --rm iron/java-dev:1.7 javac -version
+```
+
+## Building this image
+
+```sh
+docker build -t iron/java-dev:1.7 .
+```
+
+Push:
+
+```sh
+docker push iron/java-dev:1.7
+```

--- a/java/java-dev-1.8/Dockerfile
+++ b/java/java-dev-1.8/Dockerfile
@@ -3,8 +3,9 @@ FROM iron/base
 RUN echo 'http://nl.alpinelinux.org/alpine/v2.6/main' >> /etc/apk/repositories && echo 'http://nl.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
 RUN apk update && apk upgrade
 
-# openjdk7-jre-base contains no GUI support. see https://pkgs.alpinelinux.org/package/main/x86_64/openjdk7-jre-base
-RUN apk add openjdk7-jre-base
+RUN apk add openjdk8
+# puts javac in the PATH
+ENV PATH=/usr/lib/jvm/java-1.8-openjdk/bin:$PATH
 
 # Clean APK cache
 RUN rm -rf /var/cache/apk/*

--- a/java/java-dev-1.8/README.md
+++ b/java/java-dev-1.8/README.md
@@ -1,0 +1,24 @@
+# Java 1.8 JDK Image
+
+This is a small, [Alpine Linux](http://www.alpinelinux.org/) based Docker image
+that contains the Java 1.8 JDK. You can use it to compile and execute your Java code.
+
+If you're executing Java code in production, however, we recommend you use iron/java:1.8.
+
+## Using
+
+```sh
+docker run -it --rm iron/java-dev:1.8 javac -version
+```
+
+## Building this image
+
+```sh
+docker build -t iron/java-dev:1.8 .
+```
+
+Push:
+
+```sh
+docker push iron/java-dev:1.8
+```


### PR DESCRIPTION
the java-1.x images are just the JRE, we should use them for production. the java-dev-1.x ones have the JDK so used for local development, debugging, etc…

cc/ @treeder this addresses a TODO that you had in java/java-1.7/README.md

the new `iron/java-dev` images are already up [on dockerhub](https://hub.docker.com/r/iron/java-dev/) and updated readme is in https://github.com/iron-io/dockerworker/pull/20, but the `iron/java` images haven't changed. will do so when ready to merge.