### PR TITLE
mono: Importing CA Certificates into Mono's own store

### DIFF
--- a/mono/Dockerfile
+++ b/mono/Dockerfile
@@ -7,5 +7,8 @@ RUN apk update && apk upgrade
 
 RUN apk add mono@testing
 
+# Move ca certificates into Mono's certificate store (http://www.mono-project.com/docs/faq/security/)
+RUN cert-sync /etc/ssl/certs/ca-certificates.crt
+
 # Clean APK cache
 RUN rm -rf /var/cache/apk/*


### PR DESCRIPTION
As described by their [documentation](http://www.mono-project.com/docs/faq/security/), Mono uses a separate store for ca certificates.  Normally, this `cert-sync` command is ran on installation, but for whatever reason, it's not for the alpine apk. 

Using the current mono Dockerfile with this test script will result in an exception: `System.IO.IOException: The authentication or decryption has failed. ---> Mono.Security.Protocol.Tls.TlsException: Invalid certificate received from server.`
```csharp
using System;
using System.Collections.Generic;
using System.Linq;
using System.Text;
using System.Threading.Tasks;
using System.Net;

class Program
{
    static void Main(string[] args)
    {
        string data = "";
        try
        {
            data = new WebClient().DownloadString("https://auth.iron.io/");
        }
        catch (Exception ex)
        {
            data = ex.Message;
        }

        Console.WriteLine(data);
    }
}
```


Docker image build with `cert-sync` call

```shell
Sending build context to Docker daemon 17.68 MB
Step 1 : FROM iron/base
 ---> e12668964ee0
Step 2 : RUN echo '@edge http://nl.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories
 ---> Using cache
 ---> 9e78dbee41d6
Step 3 : RUN echo '@community http://nl.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories
 ---> Using cache
 ---> 2d877aef5a97
Step 4 : RUN echo '@testing http://nl.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
 ---> Using cache
 ---> 947e25f8060f
Step 5 : RUN apk update && apk upgrade
 ---> Using cache
 ---> c42c25f48ecd
Step 6 : RUN apk add mono@testing
 ---> Running in 053e4dbc3174
(1/11) Installing libbz2 (1.0.6-r4)
(2/11) Installing expat (2.1.0-r2)
(3/11) Installing libffi (3.2.1-r2)
(4/11) Installing gdbm (1.11-r1)
(5/11) Installing ncurses-terminfo-base (6.0-r6)
(6/11) Installing ncurses-terminfo (6.0-r6)
(7/11) Installing ncurses-libs (6.0-r6)
(8/11) Installing readline (6.3.008-r4)
(9/11) Installing sqlite-libs (3.9.2-r0)
(10/11) Installing python (2.7.11-r2)
(11/11) Installing mono@testing (4.0.4.1-r0)
Executing busybox-1.24.1-r7.trigger
OK: 159 MiB in 24 packages
 ---> 4f993fc207d9
Removing intermediate container 053e4dbc3174
Step 7 : RUN cert-sync /etc/ssl/certs/ca-certificates.crt
 ---> Running in fe4cc4752196
Linux Cert Store Sync - version 4.0.4.0
Synchronize local certs with certs from local Linux trust store.
Copyright 2002, 2003 Motus Technologies. Copyright 2004-2008 Novell. BSD licensed.

I already trust 0, your new list has 173
Certificate added: CN=ACCVRAIZ1, OU=PKIACCV, O=ACCV, C=ES
Certificate added: CN=ACEDICOM Root, OU=PKI, O=EDICOM, C=ES
Certificate added: C=CO, O=Sociedad Cameral de Certificación Digital - Certicámara S.A., CN=AC Raíz Certicámara S.A.
Certificate added: C=IT, L=Milan, O=Actalis S.p.A./03358520967, CN=Actalis Authentication Root CA
Certificate added: C=SE, O=AddTrust AB, OU=AddTrust External TTP Network, CN=AddTrust External CA Root
Certificate added: C=SE, O=AddTrust AB, OU=AddTrust TTP Network, CN=AddTrust Class 1 CA Root
Certificate added: C=SE, O=AddTrust AB, OU=AddTrust TTP Network, CN=AddTrust Public CA Root
Certificate added: C=SE, O=AddTrust AB, OU=AddTrust TTP Network, CN=AddTrust Qualified CA Root
Certificate added: C=US, O=AffirmTrust, CN=AffirmTrust Commercial
Certificate added: C=US, O=AffirmTrust, CN=AffirmTrust Networking
Certificate added: C=US, O=AffirmTrust, CN=AffirmTrust Premium
Certificate added: C=US, O=AffirmTrust, CN=AffirmTrust Premium ECC
Certificate added: C=JP, O=Japanese Government, OU=ApplicationCA
Certificate added: CN=Atos TrustedRoot 2011, O=Atos, C=DE
Certificate added: C=ES, CN=Autoridad de Certificacion Firmaprofesional CIF A62634068
Certificate added: C=IE, O=Baltimore, OU=CyberTrust, CN=Baltimore CyberTrust Root
Certificate added: C=NO, O=Buypass AS-983163327, CN=Buypass Class 2 CA 1
Certificate added: C=NO, O=Buypass AS-983163327, CN=Buypass Class 2 Root CA
Certificate added: C=NO, O=Buypass AS-983163327, CN=Buypass Class 3 Root CA
Certificate added: C=SK, L=Bratislava, O=Disig a.s., CN=CA Disig
Certificate added: C=SK, L=Bratislava, O=Disig a.s., CN=CA Disig Root R1
Certificate added: C=SK, L=Bratislava, O=Disig a.s., CN=CA Disig Root R2
Certificate added: C=CN, O=WoSign CA Limited, CN=CA WoSign ECC Root
Certificate added: C=CN, O=China Financial Certification Authority, CN=CFCA EV ROOT
Certificate added: C=CN, O=CNNIC, CN=CNNIC ROOT
Certificate added: C=GB, S=Greater Manchester, L=Salford, O=COMODO CA Limited, CN=COMODO Certification Authority
Certificate added: C=GB, S=Greater Manchester, L=Salford, O=COMODO CA Limited, CN=COMODO ECC Certification Authority
Certificate added: C=GB, S=Greater Manchester, L=Salford, O=COMODO CA Limited, CN=COMODO RSA Certification Authority
Certificate added: C=EU, O=AC Camerfirma SA CIF A82743287, OU=http://www.chambersign.org, CN=Chambers of Commerce Root
Certificate added: C=EU, O=AC Camerfirma SA CIF A82743287, OU=http://www.chambersign.org, CN=Global Chambersign Root
Certificate added: C=CN, O=WoSign CA Limited, CN=Certification Authority of WoSign G2
Certificate added: C=FR, O=Dhimyotis, CN=Certigna
Certificate added: C=FR, O=Certinomis, OU=0002 433998903, CN=Certinomis - Autorité Racine
Certificate added: C=FR, O=Certinomis, OU=0002 433998903, CN=Certinomis - Root CA
Certificate added: C=FR, O=Certplus, CN=Class 2 Primary CA
Certificate added: C=PL, O=Unizeto Sp. z o.o., CN=Certum CA
Certificate added: C=PL, O=Unizeto Technologies S.A., OU=Certum Certification Authority, CN=Certum Trusted Network CA
Certificate added: C=EU, L=Madrid (see current address at www.camerfirma.com/address), OID.2.5.4.5=A82743287, O=AC Camerfirma S.A., CN=Chambers of Commerce Root - 2008
Certificate added: C=CN, O=China Internet Network Information Center, CN=China Internet Network Information Center EV Certificates Root
Certificate added: CN=ComSign CA, O=ComSign, C=IL
Certificate added: C=GB, S=Greater Manchester, L=Salford, O=Comodo CA Limited, CN=AAA Certificate Services
Certificate added: C=GB, S=Greater Manchester, L=Salford, O=Comodo CA Limited, CN=Secure Certificate Services
Certificate added: C=GB, S=Greater Manchester, L=Salford, O=Comodo CA Limited, CN=Trusted Certificate Services
Certificate added: O="Cybertrust, Inc", CN=Cybertrust Global Root
Certificate added: C=DE, O=D-Trust GmbH, CN=D-TRUST Root Class 3 CA 2 2009
Certificate added: C=DE, O=D-Trust GmbH, CN=D-TRUST Root Class 3 CA 2 EV 2009
Certificate added: C=US, O=Digital Signature Trust, OU=DST ACES, CN=DST ACES CA X6
Certificate added: O=Digital Signature Trust Co., CN=DST Root CA X3
Certificate added: C=DE, O=Deutsche Telekom AG, OU=T-TeleSec Trust Center, CN=Deutsche Telekom Root CA 2
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Root CA
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Root G2
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Root G3
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Global Root CA
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Global Root G2
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Global Root G3
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert High Assurance EV Root CA
Certificate added: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Trusted Root G4
Certificate added: C=TR, L=Ankara, O=E-Tuğra EBG Bilişim Teknolojileri ve Hizmetleri A.Ş., OU=E-Tugra Sertifikasyon Merkezi, CN=E-Tugra Certification Authority
Certificate added: CN=EBG Elektronik Sertifika Hizmet Sağlayıcısı, O=EBG Bilişim Teknolojileri ve Hizmetleri A.Ş., C=TR
Certificate added: C=ES, O=Agencia Catalana de Certificacio (NIF Q-0801176-I), OU=Serveis Publics de Certificacio, OU=Vegeu https://www.catcert.net/verarrel (c)03, OU=Jerarquia Entitats de Certificacio Catalanes, CN=EC-ACC
Certificate added: C=EE, O=AS Sertifitseerimiskeskus, CN=EE Certification Centre Root CA, E=pki@sk.ee
Certificate added: O=Entrust.net, OU=www.entrust.net/CPS_2048 incorp. by ref. (limits liab.), OU=(c) 1999 Entrust.net Limited, CN=Entrust.net Certification Authority (2048)
Certificate added: C=US, O="Entrust, Inc.", OU=www.entrust.net/CPS is incorporated by reference, OU="(c) 2006 Entrust, Inc.", CN=Entrust Root Certification Authority
Certificate added: C=US, O="Entrust, Inc.", OU=See www.entrust.net/legal-terms, OU="(c) 2012 Entrust, Inc. - for authorized use only", CN=Entrust Root Certification Authority - EC1
Certificate added: C=US, O="Entrust, Inc.", OU=See www.entrust.net/legal-terms, OU="(c) 2009 Entrust, Inc. - for authorized use only", CN=Entrust Root Certification Authority - G2
Certificate added: C=US, O=Equifax, OU=Equifax Secure Certificate Authority
Certificate added: C=US, O=Equifax Secure Inc., CN=Equifax Secure Global eBusiness CA-1
Certificate added: C=US, O=Equifax Secure Inc., CN=Equifax Secure eBusiness CA-1
Certificate added: C=US, O=GeoTrust Inc., CN=GeoTrust Global CA
Certificate added: C=US, O=GeoTrust Inc., CN=GeoTrust Global CA 2
Certificate added: C=US, O=GeoTrust Inc., CN=GeoTrust Primary Certification Authority
Certificate added: C=US, O=GeoTrust Inc., OU=(c) 2007 GeoTrust Inc. - For authorized use only, CN=GeoTrust Primary Certification Authority - G2
Certificate added: C=US, O=GeoTrust Inc., OU=(c) 2008 GeoTrust Inc. - For authorized use only, CN=GeoTrust Primary Certification Authority - G3
Certificate added: C=US, O=GeoTrust Inc., CN=GeoTrust Universal CA
Certificate added: C=US, O=GeoTrust Inc., CN=GeoTrust Universal CA 2
Certificate added: OU=GlobalSign ECC Root CA - R4, O=GlobalSign, CN=GlobalSign
Certificate added: OU=GlobalSign ECC Root CA - R5, O=GlobalSign, CN=GlobalSign
Certificate added: C=BE, O=GlobalSign nv-sa, OU=Root CA, CN=GlobalSign Root CA
Certificate added: OU=GlobalSign Root CA - R2, O=GlobalSign, CN=GlobalSign
Certificate added: OU=GlobalSign Root CA - R3, O=GlobalSign, CN=GlobalSign
Certificate added: C=EU, L=Madrid (see current address at www.camerfirma.com/address), OID.2.5.4.5=A82743287, O=AC Camerfirma S.A., CN=Global Chambersign Root - 2008
Certificate added: C=US, O="The Go Daddy Group, Inc.", OU=Go Daddy Class 2 Certification Authority
Certificate added: C=US, S=Arizona, L=Scottsdale, O="GoDaddy.com, Inc.", CN=Go Daddy Root Certificate Authority - G2
Certificate added: C=GR, O=Hellenic Academic and Research Institutions Cert. Authority, CN=Hellenic Academic and Research Institutions RootCA 2011
Certificate added: C=HK, O=Hongkong Post, CN=Hongkong Post Root CA 1
Certificate added: C=FR, S=France, L=Paris, O=PM/SGDN, OU=DCSSI, CN=IGC/A, E=igca@sgdn.pm.gouv.fr
Certificate added: C=US, O=IdenTrust, CN=IdenTrust Commercial Root CA 1
Certificate added: C=US, O=IdenTrust, CN=IdenTrust Public Sector Root CA 1
Certificate added: C=ES, O=IZENPE S.A., CN=Izenpe.com
Certificate added: E=pki@sk.ee, C=EE, O=AS Sertifitseerimiskeskus, CN=Juur-SK
Certificate added: C=HU, L=Budapest, O=Microsec Ltd., OU=e-Szigno CA, CN=Microsec e-Szigno Root CA
Certificate added: C=HU, L=Budapest, O=Microsec Ltd., CN=Microsec e-Szigno Root CA 2009, E=info@e-szigno.hu
Certificate added: C=HU, L=Budapest, O=NetLock Kft., OU=Tanúsítványkiadók (Certification Services), CN=NetLock Arany (Class Gold) Főtanúsítvány
Certificate added: C=HU, L=Budapest, O=NetLock Halozatbiztonsagi Kft., OU=Tanusitvanykiadok, CN=NetLock Uzleti (Class B) Tanusitvanykiado
Certificate added: C=HU, L=Budapest, O=NetLock Halozatbiztonsagi Kft., OU=Tanusitvanykiadok, CN=NetLock Expressz (Class C) Tanusitvanykiado
Certificate added: C=HU, S=Hungary, L=Budapest, O=NetLock Halozatbiztonsagi Kft., OU=Tanusitvanykiadok, CN=NetLock Kozjegyzoi (Class A) Tanusitvanykiado
Certificate added: C=HU, L=Budapest, O=NetLock Halozatbiztonsagi Kft., OU=Tanusitvanykiadok, CN=NetLock Minositett Kozjegyzoi (Class QA) Tanusitvanykiado, E=info@netlock.hu
Certificate added: C=US, O=Network Solutions L.L.C., CN=Network Solutions Certificate Authority
Certificate added: C=CH, O=WISeKey, OU=Copyright (c) 2005, OU=OISTE Foundation Endorsed, CN=OISTE WISeKey Global Root GA CA
Certificate added: C=CH, O=WISeKey, OU=OISTE Foundation Endorsed, CN=OISTE WISeKey Global Root GB CA
Certificate added: E=contacto@procert.net.ve, L=Chacao, S=Miranda, OU=Proveedor de Certificados PROCERT, O=Sistema Nacional de Certificacion Electronica, C=VE, CN=PSCProcert
Certificate added: C=BM, O=QuoVadis Limited, OU=Root Certification Authority, CN=QuoVadis Root Certification Authority
Certificate added: C=BM, O=QuoVadis Limited, CN=QuoVadis Root CA 1 G3
Certificate added: C=BM, O=QuoVadis Limited, CN=QuoVadis Root CA 2
Certificate added: C=BM, O=QuoVadis Limited, CN=QuoVadis Root CA 2 G3
Certificate added: C=BM, O=QuoVadis Limited, CN=QuoVadis Root CA 3
Certificate added: C=BM, O=QuoVadis Limited, CN=QuoVadis Root CA 3 G3
Certificate added: O=RSA Security Inc, OU=RSA Security 2048 V3
Certificate added: C=ES, O=Generalitat Valenciana, OU=PKIGVA, CN=Root CA Generalitat Valenciana
Certificate added: C=DE, S=Baden-Wuerttemberg (BW), L=Stuttgart, O=Deutscher Sparkassen Verlag GmbH, CN=S-TRUST Authentication and Encryption Root CA 2005:PN
Certificate added: C=DE, O=Deutscher Sparkassen Verlag GmbH, OU=S-TRUST Certification Services, CN=S-TRUST Universal Root CA
Certificate added: C=JP, O="Japan Certification Services, Inc.", CN=SecureSign RootCA11
Certificate added: C=US, O=SecureTrust Corporation, CN=SecureTrust CA
Certificate added: C=US, O=SecureTrust Corporation, CN=Secure Global CA
Certificate added: C=JP, O="SECOM Trust Systems CO.,LTD.", OU=Security Communication EV RootCA1
Certificate added: C=JP, O="SECOM Trust Systems CO.,LTD.", OU=Security Communication RootCA2
Certificate added: C=JP, O=SECOM Trust.net, OU=Security Communication RootCA1
Certificate added: C=FI, O=Sonera, CN=Sonera Class1 CA
Certificate added: C=FI, O=Sonera, CN=Sonera Class2 CA
Certificate added: C=NL, O=Staat der Nederlanden, CN=Staat der Nederlanden EV Root CA
Certificate added: C=NL, O=Staat der Nederlanden, CN=Staat der Nederlanden Root CA
Certificate added: C=NL, O=Staat der Nederlanden, CN=Staat der Nederlanden Root CA - G2
Certificate added: C=NL, O=Staat der Nederlanden, CN=Staat der Nederlanden Root CA - G3
Certificate added: C=US, O="Starfield Technologies, Inc.", OU=Starfield Class 2 Certification Authority
Certificate added: C=US, S=Arizona, L=Scottsdale, O="Starfield Technologies, Inc.", CN=Starfield Root Certificate Authority - G2
Certificate added: C=US, S=Arizona, L=Scottsdale, O="Starfield Technologies, Inc.", CN=Starfield Services Root Certificate Authority - G2
Certificate added: C=IL, O=StartCom Ltd., OU=Secure Digital Certificate Signing, CN=StartCom Certification Authority
Certificate added: C=IL, O=StartCom Ltd., OU=Secure Digital Certificate Signing, CN=StartCom Certification Authority
Certificate added: C=IL, O=StartCom Ltd., CN=StartCom Certification Authority G2
Certificate added: C=CH, O=SwissSign AG, CN=SwissSign Gold CA - G2
Certificate added: C=CH, O=SwissSign AG, CN=SwissSign Platinum CA - G2
Certificate added: C=CH, O=SwissSign AG, CN=SwissSign Silver CA - G2
Certificate added: C=ch, O=Swisscom, OU=Digital Certificate Services, CN=Swisscom Root CA 1
Certificate added: C=ch, O=Swisscom, OU=Digital Certificate Services, CN=Swisscom Root CA 2
Certificate added: C=ch, O=Swisscom, OU=Digital Certificate Services, CN=Swisscom Root EV CA 2
Certificate added: C=DE, O=T-Systems Enterprise Services GmbH, OU=T-Systems Trust Center, CN=T-TeleSec GlobalRoot Class 2
Certificate added: C=DE, O=T-Systems Enterprise Services GmbH, OU=T-Systems Trust Center, CN=T-TeleSec GlobalRoot Class 3
Certificate added: C=DE, O=TC TrustCenter GmbH, OU=TC TrustCenter Class 3 CA, CN=TC TrustCenter Class 3 CA II
Certificate added: CN=TÜRKTRUST Elektronik Sertifika Hizmet Sağlayıcısı, C=TR, L=Ankara, O=TÜRKTRUST Bilgi İletişim ve Bilişim Güvenliği Hizmetleri A.Ş. (c) Aralık 2007
Certificate added: C=TW, O=TAIWAN-CA, OU=Root CA, CN=TWCA Global Root CA
Certificate added: C=TW, O=TAIWAN-CA, OU=Root CA, CN=TWCA Root Certification Authority
Certificate added: C=TW, O=Government Root Certification Authority
Certificate added: O=TeliaSonera, CN=TeliaSonera Root CA v1
Certificate added: C=GB, O=Trustis Limited, OU=Trustis FPS Root CA
Certificate added: C=TR, L=Gebze - Kocaeli, O=Türkiye Bilimsel ve Teknolojik Araştırma Kurumu - TÜBİTAK, OU=Ulusal Elektronik ve Kriptoloji Araştırma Enstitüsü - UEKAE, OU=Kamu Sertifikasyon Merkezi, CN=TÜBİTAK UEKAE Kök Sertifika Hizmet Sağlayıcısı - Sürüm 3
Certificate added: C=TR, L=Ankara, O=TÜRKTRUST Bilgi İletişim ve Bilişim Güvenliği Hizmetleri A.Ş., CN=TÜRKTRUST Elektronik Sertifika Hizmet Sağlayıcısı H5
Certificate added: C=TR, L=Ankara, O=TÜRKTRUST Bilgi İletişim ve Bilişim Güvenliği Hizmetleri A.Ş., CN=TÜRKTRUST Elektronik Sertifika Hizmet Sağlayıcısı H6
Certificate added: C=US, S=New Jersey, L=Jersey City, O=The USERTRUST Network, CN=USERTrust ECC Certification Authority
Certificate added: C=US, S=New Jersey, L=Jersey City, O=The USERTRUST Network, CN=USERTrust RSA Certification Authority
Certificate added: C=US, S=UT, L=Salt Lake City, O=The USERTRUST Network, OU=http://www.usertrust.com, CN=UTN-USERFirst-Client Authentication and Email
Certificate added: C=US, S=UT, L=Salt Lake City, O=The USERTRUST Network, OU=http://www.usertrust.com, CN=UTN-USERFirst-Hardware
Certificate added: C=US, O="VeriSign, Inc.", OU=VeriSign Trust Network, OU="(c) 2007 VeriSign, Inc. - For authorized use only", CN=VeriSign Class 3 Public Primary Certification Authority - G4
Certificate added: C=US, O="VeriSign, Inc.", OU=VeriSign Trust Network, OU="(c) 2006 VeriSign, Inc. - For authorized use only", CN=VeriSign Class 3 Public Primary Certification Authority - G5
Certificate added: C=US, O="VeriSign, Inc.", OU=VeriSign Trust Network, OU="(c) 2008 VeriSign, Inc. - For authorized use only", CN=VeriSign Universal Root Certification Authority
Certificate added: C=US, O="VeriSign, Inc.", OU=Class 1 Public Primary Certification Authority
Certificate added: C=US, O="VeriSign, Inc.", OU=Class 1 Public Primary Certification Authority - G2, OU="(c) 1998 VeriSign, Inc. - For authorized use only", OU=VeriSign Trust Network
Certificate added: C=US, O="VeriSign, Inc.", OU=VeriSign Trust Network, OU="(c) 1999 VeriSign, Inc. - For authorized use only", CN=VeriSign Class 1 Public Primary Certification Authority - G3
Certificate added: C=US, O="VeriSign, Inc.", OU=Class 2 Public Primary Certification Authority - G2, OU="(c) 1998 VeriSign, Inc. - For authorized use only", OU=VeriSign Trust Network
Certificate added: C=US, O="VeriSign, Inc.", OU=VeriSign Trust Network, OU="(c) 1999 VeriSign, Inc. - For authorized use only", CN=VeriSign Class 2 Public Primary Certification Authority - G3
Certificate added: C=US, O="VeriSign, Inc.", OU=Class 3 Public Primary Certification Authority
Certificate added: C=US, O="VeriSign, Inc.", OU=Class 3 Public Primary Certification Authority - G2, OU="(c) 1998 VeriSign, Inc. - For authorized use only", OU=VeriSign Trust Network
Certificate added: C=US, O="VeriSign, Inc.", OU=VeriSign Trust Network, OU="(c) 1999 VeriSign, Inc. - For authorized use only", CN=VeriSign Class 3 Public Primary Certification Authority - G3
Certificate added: C=US, O="VeriSign, Inc.", OU=Class 3 Public Primary Certification Authority
Certificate added: C=US, O=VISA, OU=Visa International Service Association, CN=Visa eCommerce Root
Certificate added: C=US, O=Wells Fargo WellsSecure, OU=Wells Fargo Bank NA, CN=WellsSecure Public Root Certificate Authority
Certificate added: C=CN, O=WoSign CA Limited, CN=Certification Authority of WoSign
Certificate added: C=CN, O=WoSign CA Limited, CN=CA 沃通根证书
Certificate added: C=US, OU=www.xrampsecurity.com, O=XRamp Security Services Inc, CN=XRamp Global Certification Authority
Certificate added: C=RO, O=certSIGN, OU=certSIGN ROOT CA
Certificate added: C=TW, O="Chunghwa Telecom Co., Ltd.", OU=ePKI Root Certification Authority
Certificate added: C=US, O="thawte, Inc.", OU=Certification Services Division, OU="(c) 2006 thawte, Inc. - For authorized use only", CN=thawte Primary Root CA
Certificate added: C=US, O="thawte, Inc.", OU="(c) 2007 thawte, Inc. - For authorized use only", CN=thawte Primary Root CA - G2
Certificate added: C=US, O="thawte, Inc.", OU=Certification Services Division, OU="(c) 2008 thawte, Inc. - For authorized use only", CN=thawte Primary Root CA - G3
173 new root certificates were added to your trust store.
Import process completed.
 ---> 92d54ace0a07
Removing intermediate container fe4cc4752196
Step 8 : RUN rm -rf /var/cache/apk/*
 ---> Running in f664fd898af4
 ---> c7208eac23bf
Removing intermediate container f664fd898af4
Successfully built c7208eac23bf
```

Test script succeeds with this new image. @treeder 