### PR TITLE
Conform to Docker best practices

### DIFF
--- a/elixir/Dockerfile
+++ b/elixir/Dockerfile
@@ -1,14 +1,9 @@
 FROM iron/base
 
-RUN echo '@edge http://nl.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories
-RUN echo '@community http://nl.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories
-RUN apk update && apk upgrade
-
-RUN apk add erlang-crypto@edge
-RUN apk add elixir@edge
-
-# this line and maybe crypto package above may only be required when building
-RUN mix local.hex --force
-
-# Clean APK cache
-RUN rm -rf /var/cache/apk/*
+RUN echo '@edge http://nl.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories \
+  && echo '@community http://nl.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories \
+  && apk update && apk upgrade \
+  && apk add erlang-crypto@edge \
+  && apk add elixir@edge \
+  && mix local.hex --force \
+  && rm -rf /var/cache/apk/*


### PR DESCRIPTION
* in-lines the various run commands
* confirms that the crypto package is required beyond this build
* shrinks the resulting image about 5%