### PR TITLE
Add a Clojure/Leiningen Dockerfile.

### DIFF
--- a/clojure/Dockerfile
+++ b/clojure/Dockerfile
@@ -1,0 +1,14 @@
+FROM iron/java:1.8
+
+# To disable warning
+ENV LEIN_ROOT 1
+ENV LEIN_VERSION 2.6.1
+
+RUN apk add --update wget ca-certificates bash && \
+    wget -q "https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein" -O /usr/local/bin/lein && \
+    chmod 0755 /usr/local/bin/lein && \
+    lein && \
+
+    # Do clean up
+    apk del wget ca-certificates && \
+    rm -rf /tmp/* /var/cache/apk/*

--- a/clojure/README.md
+++ b/clojure/README.md
@@ -1,0 +1,11 @@
+# Leiningen Docker image
+This is a small [Alpine Linux](http://www.alpinelinux.org/) based image for running Clojure applications that are built using [Leiningen](http://leiningen.org/).
+
+## Build
+
+    docker build -t leiningen .
+
+## Run
+To run a Clojure repl:
+
+	docker run -it leiningen lein repl

--- a/clojure/dev/Dockerfile
+++ b/clojure/dev/Dockerfile
@@ -1,0 +1,17 @@
+FROM iron/java:1.8
+
+# To disable warning
+ENV LEIN_ROOT 1
+ENV LEIN_VERSION 2.6.1
+
+RUN apk add --update wget ca-certificates bash curl git
+
+# Required by Figwheel
+RUN apk add rlwrap --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted
+
+RUN wget -q "https://raw.githubusercontent.com/technomancy/leiningen/$LEIN_VERSION/bin/lein" -O /usr/local/bin/lein
+
+RUN chmod 0755 /usr/local/bin/lein && lein
+
+# Clean up
+RUN apk del wget ca-certificates && rm -rf /tmp/* /var/cache/apk/*

--- a/clojure/dev/README.md
+++ b/clojure/dev/README.md
@@ -1,0 +1,11 @@
+# Leiningen Docker image
+This is a small [Alpine Linux](http://www.alpinelinux.org/) based image for running Clojure applications that are built using [Leiningen](http://leiningen.org/).
+
+## Build
+
+    docker build -t leiningen:dev .
+
+## Run
+To run a Clojure repl:
+
+	docker run -it leiningen:dev lein repl


### PR DESCRIPTION
I've created a Clojure (Leiningen) Dockerfile based on `iron/java:1.8`. 

I'm aware there is another open [pull request](https://github.com/iron-io/dockers/pull/8) but it's been inactive for a while.

Virtual image size is 124.6 MB.