### PR TITLE
Add php7-mbstring extension to fix composer installation

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -3,7 +3,7 @@ FROM iron/base
 RUN echo '@testing http://nl.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
 
 RUN apk update && apk upgrade \
-  && apk add php7@testing php7-openssl@testing php7-phar@testing php7-json@testing php7-curl@testing \
+  && apk add php7@testing php7-openssl@testing php7-phar@testing php7-json@testing php7-curl@testing php7-mbstring@testing \
   && rm -rf /var/cache/apk/*
 
 RUN ln -s /usr/bin/php7 /usr/bin/php


### PR DESCRIPTION
Without this extension, running build.rb on OS-X fails with:

Step 2 : RUN curl -sS https://getcomposer.org/installer | php
 ---> Running in b918100ad154
Some settings on your machine make Composer unable to work properly.
Make sure that you fix the issues listed below and run this script again:

The iconv OR mbstring extension is required and both are missing.
Install either of them or recompile php without --disable-iconv