### PR TITLE
build go dev container from source

### DIFF
--- a/go/dev/Dockerfile
+++ b/go/dev/Dockerfile
@@ -4,10 +4,14 @@ RUN echo '@edge http://nl.alpinelinux.org/alpine/edge/main' >> /etc/apk/reposito
 RUN echo '@community http://nl.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories
 
 RUN apk update && apk upgrade
-RUN apk add curl make git bzr mercurial go@community alpine-sdk
-
+RUN apk add wget curl make git bzr mercurial bash go@community alpine-sdk
+RUN which go
+ENV GOROOT_BOOTSTRAP /usr/lib/go
+RUN git clone https://go.googlesource.com/go
+RUN cd go && git checkout go1.8 && cd src && ./make.bash
+ENV PATH="${PWD}/go/bin:${PATH}"
 RUN rm -rf /var/cache/apk/*
 
-RUN mkdir /go
-ENV GOPATH /go
+RUN mkdir /gocode
+ENV GOPATH /gocode
 


### PR DESCRIPTION
i've already pushed this to iron/go:dev cuz we sadly need it to work for our internal tests and this is probably easier than rewriting those, this will be useful cuz alpine community go wasn't even up to date, now we can just install latest from source every time. sidebar, it's a total pain keeping this up to date, we should play with something more official