### PR TITLE
Allow CGO_ENABLED=1

### DIFF
--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,4 +1,6 @@
 FROM iron/base:edge
 
+RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+
 # The Go image doesn't need anything else.
 # Use iron/go:dev to build.


### PR DESCRIPTION
Dynamically linked Go applications compiled with CGO_ENABLED=1 on a system with glibc (default on debian based distros) instead of musl (default on alpine) can now run inside an iron/go container.