### PR TITLE
Updated golang image to 1.9 by using `golang:1.9-alpine` and glide im…

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.7
 
 RUN apk update && apk upgrade \
   && apk add ca-certificates \

--- a/go/build.rb
+++ b/go/build.rb
@@ -15,14 +15,14 @@ p v
 # returns: go version go1.6 linux/amd64
 v = v.split(' ')[2]
 p v
-v = v[2..v.length]
+v = v[2..(v.length)]
 p v
-v += ".0"
-p v
-vtag(name, tag, v, true)
+new_tags = vtag(name, tag, v, true)
 
 Dir.chdir '../'
 p Dir.pwd
 tag = "latest"
 build("#{name}:#{tag}")
-vtag(name, tag, v, false)
+new_tags += vtag(name, tag, v, false)
+
+push_all(name, new_tags)

--- a/go/dev/Dockerfile
+++ b/go/dev/Dockerfile
@@ -1,17 +1,3 @@
-FROM iron/base:edge
+FROM golang:1.9-alpine
 
-RUN echo '@edge http://nl.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories
-RUN echo '@community http://nl.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories
-
-RUN apk update && apk upgrade
-RUN apk add wget curl make git bzr mercurial bash go@community alpine-sdk
-RUN which go
-ENV GOROOT_BOOTSTRAP /usr/lib/go
-RUN git clone https://go.googlesource.com/go
-RUN cd go && git checkout go1.8 && cd src && ./make.bash
-ENV PATH="${PWD}/go/bin:${PATH}"
-RUN rm -rf /var/cache/apk/*
-
-RUN mkdir /gocode
-ENV GOPATH /gocode
-
+RUN apk add --no-cache wget curl git build-base

--- a/go/glide/Dockerfile
+++ b/go/glide/Dockerfile
@@ -1,5 +1,5 @@
 FROM iron/go:dev
 
 RUN apk update && apk upgrade
-RUN wget https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz
-RUN tar -C /bin -xvzf glide-v0.12.3-linux-amd64.tar.gz --strip=1
+RUN wget https://github.com/Masterminds/glide/releases/download/v0.13.1/glide-v0.13.1-linux-amd64.tar.gz
+RUN tar -C /bin -xvzf glide-v0.13.1-linux-amd64.tar.gz --strip=1


### PR DESCRIPTION
Updated golang image to 1.9 by using `golang:1.9-alpine` and glide image to 0.13.1.
Inherited base image from stable `alpine:3.7`.

Borrowed the changes from [fnproject](https://github.com/fnproject/dockers). Thank you Travis and Reed!