### PR TITLE
No `use-system-libraries` to build Nokogiri

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -10,12 +10,6 @@ Image on Docker Hub: https://hub.docker.com/r/iron/ruby
 docker run --rm -v "$PWD":/worker -w /worker iron/ruby:dev bundle install --standalone --clean
 ```
 
-If you're using Nokogiri, use this one:
-
-```sh
-docker run --rm -v "$PWD":/worker -w /worker iron/ruby:dev sh -c 'bundle config --local build.nokogiri --use-system-libraries && bundle install --standalone --clean'
-```
-
 Then require the vendored gems. Notice in `hello.rb`, we add the following so it uses the vendored gems:
 
 ```ruby


### PR DESCRIPTION
Removed separate build instructions for Nokogiri, because its current version is able to build without `use-system-libraries`.
Fixes https://github.com/iron-io/dockers/issues/53.

Test plan:
```
# Put test code from https://github.com/sparklemotion/nokogiri#synopsis to test.rb
# Insert `require_relative 'bundle/bundler/setup'` into second line of test.rb

cat << EOF > Gemfile
source 'https://rubygems.org'
gem 'nokogiri'
EOF

docker run --rm -v "$PWD":/worker -w /worker iron/ruby:dev bundle install --standalone --clean

docker run --rm -v "$PWD":/worker -w /worker iron/ruby ruby test.rb
```