### PR TITLE
Updated node image to 9.9.0 by using official images

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,9 +1,1 @@
-FROM iron/base:edge
-
-RUN echo '@edge http://nl.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories
-# RUN echo '@community http://nl.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories
-
-RUN apk update && apk upgrade \
-  && apk add nodejs@edge \
-  && npm uninstall -g npm \
-  && rm -rf /var/cache/apk/*
+FROM node:alpine

--- a/node/dev/Dockerfile
+++ b/node/dev/Dockerfile
@@ -1,9 +1,1 @@
-FROM iron/base:edge
-
-RUN echo '@edge http://nl.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories
-# RUN echo '@community http://nl.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories
-
-RUN apk update && apk upgrade \
-  && apk add git build-base nodejs-dev@edge nodejs@edge \
-  && npm install -g npm \
-  && rm -rf /var/cache/apk/*
+FROM node:alpine


### PR DESCRIPTION
Updated node image to 9.9.0 by using official `node:alpine`.

Borrowed the changes from [fnproject](https://github.com/fnproject/dockers). Thank you Travis and Reed!