### PR TITLE
Updated python images to 2.7.14 and 3.6.3

### DIFF
--- a/python/build.rb
+++ b/python/build.rb
@@ -14,13 +14,13 @@ p v
 # returns: Python 2.7.11
 v = v.split(' ')[1]
 p v
-vtag(name, tag, v)
+new_tags = vtag(name, tag, v)
 
 Dir.chdir 'dev'
 tag = "2-dev"
 build("#{name}:#{tag}")
 p v
-vtag(name, tag, v, true)
+new_tags += vtag(name, tag, v, true)
 
 # now 3
 Dir.chdir '../../python3'
@@ -32,10 +32,12 @@ p v
 # returns: Python 2.7.11
 v = v.split(' ')[1]
 p v
-vtag(name, tag, v, false)
+new_tags += vtag(name, tag, v, false)
 
 Dir.chdir 'dev'
 tag = "dev"
 build("#{name}:#{tag}")
 p v
-vtag(name, tag, v, true)
+new_tags += vtag(name, tag, v, true)
+
+push_all(name, new_tags)

--- a/python/python2/Dockerfile
+++ b/python/python2/Dockerfile
@@ -1,5 +1,3 @@
 FROM iron/base
 
-RUN apk update && apk upgrade \
-  && apk add python \
-  && rm -rf /var/cache/apk/*
+RUN apk add --no-cache python

--- a/python/python2/dev/Dockerfile
+++ b/python/python2/dev/Dockerfile
@@ -1,11 +1,5 @@
 FROM iron/python:2
 
-RUN apk update && apk upgrade
-
-RUN apk add curl
-RUN apk add python
+RUN apk add --no-cache build-base curl git linux-headers python python2-dev py-setuptools
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python
-
-# Clean APK cache
-RUN rm -rf /var/cache/apk/*

--- a/python/python2/dev/README.md
+++ b/python/python2/dev/README.md
@@ -2,5 +2,5 @@
 ## Using
 
 ```sh
-docker run -it --rm iron/python python --version
+docker run -it --rm iron/python:2-dev python --version
 ```

--- a/python/python3/Dockerfile
+++ b/python/python3/Dockerfile
@@ -1,5 +1,3 @@
 FROM iron/base
 
-RUN apk update && apk upgrade \
-  && apk add python3 \
-  && rm -rf /var/cache/apk/*
+RUN apk add --no-cache python3

--- a/python/python3/README.md
+++ b/python/python3/README.md
@@ -2,5 +2,5 @@
 ## Using
 
 ```sh
-docker run -it --rm iron/python3 python3 --version
+docker run -it --rm iron/python python3 --version
 ```

--- a/python/python3/dev/Dockerfile
+++ b/python/python3/dev/Dockerfile
@@ -1,11 +1,5 @@
 FROM iron/python:3
 
-RUN apk update && apk upgrade
-
-RUN apk add curl
-RUN apk add python3
+RUN apk add --no-cache build-base curl git linux-headers python3 python3-dev
 
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3
-
-# Clean APK cache
-RUN rm -rf /var/cache/apk/*

--- a/python/python3/dev/README.md
+++ b/python/python3/dev/README.md
@@ -2,5 +2,5 @@
 ## Using
 
 ```sh
-docker run -it --rm iron/python python --version
+docker run -it --rm iron/python:dev python3 --version
 ```


### PR DESCRIPTION
Updated python images to 2.7.14 and 3.6.3 respectively.
Added build-base for dev images to build native extensions.

Borrowed the changes from  [fnproject](https://github.com/fnproject/dockers). Thank you Travis and all fnproject contributors!