### PR TITLE
Updated golang image to 1.10.2

### DIFF
--- a/go/dev/Dockerfile
+++ b/go/dev/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:1.9-alpine
+FROM golang:1.10.2-alpine
 
 RUN apk add --no-cache wget curl git build-base


### PR DESCRIPTION
Updated golang image to 1.10.2 by using `golang:1.10.2-alpine`.

Borrowed the changes from [fnproject](https://github.com/fnproject/dockers). Thank you Travis and Reed!