### PR TITLE
Upgrade glide from v0.13.1 to v0.13.3

### DIFF
--- a/go/glide/Dockerfile
+++ b/go/glide/Dockerfile
@@ -1,5 +1,5 @@
 FROM iron/go:dev
 
 RUN apk update && apk upgrade
-RUN wget https://github.com/Masterminds/glide/releases/download/v0.13.1/glide-v0.13.1-linux-amd64.tar.gz
-RUN tar -C /bin -xvzf glide-v0.13.1-linux-amd64.tar.gz --strip=1
+RUN wget https://github.com/Masterminds/glide/releases/download/v0.13.3/glide-v0.13.3-linux-amd64.tar.gz
+RUN tar -C /bin -xvzf glide-v0.13.3-linux-amd64.tar.gz --strip=1


### PR DESCRIPTION
Upgraded glide from v0.13.1 to v0.13.3
New url to fetch from: https://github.com/Masterminds/glide/releases/download/v0.13.3/glide-v0.13.3-linux-amd64.tar.gz