### PR TITLE
Update from golang:1.10.2 to golang:1.16-alpine

### DIFF
--- a/go/dev/Dockerfile
+++ b/go/dev/Dockerfile
@@ -1,3 +1,3 @@
-FROM golang:1.10.2-alpine
+FROM golang:1.16-alpine
 
 RUN apk add --no-cache wget curl git build-base


### PR DESCRIPTION
Update from golang:1.10.2 to golang:1.16-alpine